### PR TITLE
Allow user to set language_in, language_out, and compilation_level settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,15 +4,17 @@ var RawSource = require('webpack-core/lib/RawSource');
 
 function ClosureCompilerPlugin(options) {
 
-  if (typeof options !== 'object') {
-    options = {};
+  var _options = {};
+
+  _options['language_in'] = 'ES5';
+  _options['language_out'] = 'ES5';
+  _options['compilation_level'] = 'ADVANCED';
+
+  for (var key in options) {
+    _options[key] = options[key];
   }
 
-  options['language_in'] = 'ES5';
-  options['language_out'] = 'ES5';
-  options['compilation_level'] = 'ADVANCED';
-
-  this.options = options;
+  this.options = _options;
 }
 
 ClosureCompilerPlugin.prototype.apply = function(compiler) {


### PR DESCRIPTION
Currently, if you try to specify any of `language_in`, `language_out`, or `compilation_level`, they are overwritten before the compiler is run. This makes it impossible to run `webpack-closure-compiler` using `SIMPLE_OPTIMIZATIONS`.

This PR fixes that.
