### PR TITLE
Fix runner.js

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -8,7 +8,7 @@ path = require('path');
 
 JAVA_PATH = exports.JAVA_PATH = 'java';
 
-JAR_PATH = exports.JAR_PATH = path.join(__dirname, '../node_modules/google-closure-compiler/compiler.jar');
+JAR_PATH = exports.JAR_PATH = require.resolve('google-closure-compiler/compiler.jar');
 
 OPTIONS = exports.OPTIONS = {};
 


### PR DESCRIPTION
NPM uses flat deps now so the jar does not work. require.resolve finds the path of the JAR_FILE better.
