### PR TITLE
Update google-closure-compiler deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.5.0",
-    "google-closure-compiler": "^20160517.1.0",
-    "google-closure-compiler-js": "^20160822.0.0",
+    "google-closure-compiler": "^20160911.0.0",
+    "google-closure-compiler-js": "^20160916.0.0",
     "temp": "^0.8.3",
     "webpack-core": "^0.6.8"
   },


### PR DESCRIPTION
Update `google-closure-compiler` to 20160911.0.0 and `google-closure-compiler-js` to 20160916.0.0

These releases add native support to compose input source maps into the output source map 🎉.
